### PR TITLE
Add press release link and its input widget

### DIFF
--- a/_data/featured.yaml
+++ b/_data/featured.yaml
@@ -1,4 +1,5 @@
 meetings:
+  - featured: October 27-28, 2022
   - featured: May 12, 2022 Council Meeting
 reports:
   - featured: Disparate Treatment of Puerto Rico Residents with Disabilities in

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -51,6 +51,21 @@ This is used in blog posts. The index page can be found at blog/index.html
         {% endif %}
         {% if page.agenda or page.minutes or page.federal_register_notice %}
           <div class="padding-y-2">
+            {% if page.press_release %}
+              <div>
+                <div class="display-flex flex-row flex-align-center">
+                  <a
+                    class="display-flex flex-row flex-align-center text-bold text-no-underline"
+                    href="{{page.press_release}}"
+                  >
+                    Press Release
+                    <svg class="usa-icon margin-left-1" aria-hidden="true" role="img">
+                      <use xlink:href="{% asset img/sprite.svg @path %}#info_outline"></use>
+                    </svg>
+                  </a>
+                </div>
+              </div>
+            {% endif %}
             {% if page.federal_register_notice %}
               <div>
                 <div class="display-flex flex-row flex-align-center">

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -111,6 +111,13 @@ collections:
             },
         }
       - { label: 'Title', name: 'title', widget: 'string' }
+      - &press-release {
+          label: 'Press Release',
+          name: 'press_release',
+          widget: 'string',
+          required: false,
+          hint: 'Enter the URL or relative path for the related press release or news post.',
+        }
       - { label: 'Body', name: 'body', widget: 'markdown' }
   - label: Committees & Communities
     name: committees-communities
@@ -156,6 +163,7 @@ collections:
           max: 5,
           required: false,
         }
+      - *press-release
       - {
           label: 'Publish Date',
           name: 'date',
@@ -359,6 +367,7 @@ collections:
           media_folder: '/_assets/uploads/meetings/{{year}}/{{slug}}',
           public_folder: 'meetings/{{year}}/{{slug}}',
         }
+      - *press-release
       - { label: 'Body', name: 'body', widget: 'markdown' }
   - label: Navigation for Site
     name: navigation
@@ -508,6 +517,7 @@ collections:
         }
       - *policy-areas
       - *categories
+      - *press-release
       - {
           label: 'Report Document',
           name: 'document',
@@ -549,6 +559,7 @@ collections:
         }
       - *policy-areas
       - *categories
+      - *press-release
       - {
           label: 'Report Word Document',
           name: 'word_document',


### PR DESCRIPTION
Adds the ability to add a "Press Release" link to different collection items if there is a corresponding news post about the item. Displays the press release link in the item page.