### PR TITLE
Fix video track captions

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -114,7 +114,7 @@ layout: default
         {% endif %}
         {% if page.video_url and page.video_url != nil and page.video_url != '' %}
           <div class="padding-y-2">
-            {% include video/player.html video_url=page.video_url video_caption_track=item.video_caption_track %}
+            {% include video/player.html video_url=page.video_url video_caption_track=page.video_caption_track %}
           </div>
         {% endif %}
         {{ content }}

--- a/_layouts/single-page.html
+++ b/_layouts/single-page.html
@@ -13,7 +13,7 @@ layout: wide
 
       {% if page.video_url and page.video_url != nil and page.video_url != '' %}
         <div class="padding-y-2">
-          {% include video/player.html video_url=page.video_url video_caption_track=item.video_caption_track %}
+          {% include video/player.html video_url=page.video_url video_caption_track=page.video_caption_track %}
         </div>
       {% endif %}
 


### PR DESCRIPTION
Fixes the video track captions.

- [Preview](https://federalist-2a0310cc-a722-4ce4-a0ff-d41c4b688bf4.sites.pages.cloud.gov/preview/ncdgov/ncd-site/fix-video-captions/meeting/2024-02-08-feb-8-2024-council-meeting/)